### PR TITLE
💄 검색 결과 페이지 UI 구현

### DIFF
--- a/FrontEnd/poyo/public/img/back.svg
+++ b/FrontEnd/poyo/public/img/back.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="21" viewBox="0 0 24 21" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M24 9.1376H4.98925L11.8879 1.92643L10.045 0L0 10.5L10.045 21L11.8879 19.0736L4.98925 11.8624H24V9.1376Z" fill="#19191B"/>
+</svg>

--- a/FrontEnd/poyo/src/App.js
+++ b/FrontEnd/poyo/src/App.js
@@ -3,12 +3,14 @@ import loadable from "@loadable/component";
 import "./styles/globals.css";
 
 const Main = loadable(() => import("./pages/Main"));
+const Search = loadable(() => import("./pages/Search"));
 const Detail = loadable(() => import("./pages/Detail"));
 
 function App() {
   return (
     <Routes>
       <Route path="/" element={<Main />} />
+      <Route path="/search/:id" element={<Search />} />
       <Route path="/detail" element={<Detail />} />
     </Routes>
   );

--- a/FrontEnd/poyo/src/components/BackBtn.js
+++ b/FrontEnd/poyo/src/components/BackBtn.js
@@ -1,0 +1,19 @@
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+
+export const BackButton = () => {
+  const navigate = useNavigate();
+
+  return (
+    <button onClick={() => navigate("/")}>
+      <ArrowBackIcon src="/img/back.svg" />
+    </button>
+  );
+};
+
+const ArrowBackIcon = styled.img`
+  position: fixed;
+  margin: 1.7rem 1.5rem 1.2rem;
+  width: 20px;
+  height: 20px;
+`;

--- a/FrontEnd/poyo/src/components/home/Home.js
+++ b/FrontEnd/poyo/src/components/home/Home.js
@@ -1,4 +1,4 @@
-import Search from "./Search";
+import SearchInput from "./SearchInput";
 import styled from "styled-components";
 import Category from "./Category";
 
@@ -6,7 +6,7 @@ export default function Home() {
   return (
     <>
       <Logo src="img/logo.svg" alt="" />
-      <Search />
+      <SearchInput />
       <Category />
     </>
   );

--- a/FrontEnd/poyo/src/components/home/PopularSearch.js
+++ b/FrontEnd/poyo/src/components/home/PopularSearch.js
@@ -5,7 +5,7 @@ export default function PopularSearch() {
   const dummy = [
     {
       id: 1,
-      word: "미스테리",
+      word: "미스테",
     },
     {
       id: 2,
@@ -47,7 +47,9 @@ export default function PopularSearch() {
         {dummy.map((v) => {
           return (
             <Word key={v.id}>
-              <p>{v.word}</p>
+              <p>
+                {v.id}. {v.word}
+              </p>
             </Word>
           );
         })}

--- a/FrontEnd/poyo/src/components/home/SearchInput.js
+++ b/FrontEnd/poyo/src/components/home/SearchInput.js
@@ -5,31 +5,31 @@ import { COLORS } from "../../constants";
 import PopularSearch from "./PopularSearch";
 
 export default function SearchInput() {
+  const navigate = useNavigate();
 
-
-  const navigate = useNavigate()
-
-  const [search, setSearch] = useState("")
-
-
+  const [search, setSearch] = useState("");
 
   const onChangeSearch = (e) => {
-    e.preventDefault()
-    setSearch(e.target.value)
-  }
-
-  console.log(search);
+    e.preventDefault();
+    setSearch(e.target.value);
+  };
 
   const onSubmit = (e) => {
-    e.preventDefault()
-    navigate(`/search/${search}`, { state: search })
-  }
+    e.preventDefault();
+    navigate(`/search/${search}`, { state: search });
+  };
 
   return (
     <>
       <Form onSubmit={onSubmit}>
         <Label htmlFor="search">
-          <SearchInp id="search" type="text" placeholder="Search" value={search} onChange={onChangeSearch} />
+          <SearchInp
+            id="search"
+            type="text"
+            placeholder="Search"
+            value={search}
+            onChange={onChangeSearch}
+          />
           <button type="submit"></button>
         </Label>
       </Form>

--- a/FrontEnd/poyo/src/components/home/SearchInput.js
+++ b/FrontEnd/poyo/src/components/home/SearchInput.js
@@ -1,13 +1,36 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import { COLORS } from "../../constants";
 import PopularSearch from "./PopularSearch";
 
-export default function Search() {
+export default function SearchInput() {
+
+
+  const navigate = useNavigate()
+
+  const [search, setSearch] = useState("")
+
+
+
+  const onChangeSearch = (e) => {
+    e.preventDefault()
+    setSearch(e.target.value)
+  }
+
+  console.log(search);
+
+  const onSubmit = (e) => {
+    e.preventDefault()
+    navigate(`/search/${search}`, { state: search })
+  }
+
   return (
     <>
-      <Form>
+      <Form onSubmit={onSubmit}>
         <Label htmlFor="search">
-          <SearchInp id="search" type="text" placeholder="Search" />
+          <SearchInp id="search" type="text" placeholder="Search" value={search} onChange={onChangeSearch} />
+          <button type="submit"></button>
         </Label>
       </Form>
       <PopularSearch />
@@ -30,6 +53,9 @@ const Label = styled.label`
     width: 1.5rem;
     height: 1.5rem;
     background: url("/img/search.svg") no-repeat center;
+  }
+  button {
+    display: none;
   }
 `;
 

--- a/FrontEnd/poyo/src/components/search/SearchResult.js
+++ b/FrontEnd/poyo/src/components/search/SearchResult.js
@@ -17,34 +17,47 @@ export default function SearchResult() {
   const searchDummy = [
     {
       id: 1,
+      image:
+        "https://image.ytn.co.kr/general/jpg/2021/0311/202103110915014429_d.jpg",
       word: location.state + " 맨션 (Suspects)",
     },
     {
       id: 2,
+      image: "https://dimg.donga.com/wps/NEWS/IMAGE/2010/06/25/29410677.1.jpg",
       word: location.state + " 사건 사고",
     },
     {
       id: 3,
+      image:
+        "https://www.theguru.co.kr/data/photos/20210310/art_16152560003284_ac2b0e.jpg",
       word: location.state + " 블로그",
     },
     {
       id: 4,
+      image:
+        "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTGQgQgO17Fge1x1EwPp1JnjINvfFdpyeVe2A&usqp=CAU",
       word: location.state + " 불가사의",
     },
     {
       id: 5,
+      image: "https://pbs.twimg.com/media/FPepTVraAAIDjfW.png:small",
       word: location.state + " 캔디",
     },
     {
       id: 6,
+      image: "https://cdn.techm.kr/news/photo/202012/78574_74356_3753.jpg",
       word: location.state + " 부루마블",
     },
     {
       id: 7,
+      image:
+        "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQy-5cbYm9I0ALWYcykasXaGjYYJ2npSJcI4MZQGAQgdp7Io2fTD9TqPlnq6LEl4iAiuoY&usqp=CAU",
       word: location.state + " 산장의 기억",
     },
     {
       id: 8,
+      image:
+        "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcStoWlSfskVeITb1LyAuQCauH9MpeI79RZE5A&usqp=CAU",
       word: location.state + " 오레오",
     },
   ];
@@ -71,8 +84,9 @@ export default function SearchResult() {
       <ul>
         {searchDummy.map((v) => {
           return (
-            <SearchList>
+            <SearchList key={v.id}>
               <Link to={`/detail`}>
+                <img src={v.image} alt="" />
                 <span>{v.word}</span>
               </Link>
             </SearchList>
@@ -84,7 +98,7 @@ export default function SearchResult() {
 }
 
 const Form = styled.form`
-  margin: 4.4rem auto 1.2rem;
+  margin: 4.4rem auto 1.5rem;
   width: calc(100% - 3rem);
 `;
 
@@ -122,9 +136,22 @@ const SearchInp = styled.input`
 `;
 
 const SearchList = styled.li`
-  margin: 0.7rem auto;
+  padding: 0 0 0.5rem;
+  margin: 0.7rem auto 1.2rem;
   width: calc(100% - 3.7rem);
   font-size: 0.92rem;
+  /* border-bottom: 0.05rem solid ${COLORS.light_gray}; */
+  a {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+  img {
+    width: 3.4rem;
+    height: 3.4rem;
+    border-radius: 0.5rem;
+    object-fit: cover;
+  }
   span {
     display: block;
     padding: 1.3rem 0;

--- a/FrontEnd/poyo/src/components/search/SearchResult.js
+++ b/FrontEnd/poyo/src/components/search/SearchResult.js
@@ -1,0 +1,133 @@
+import { useState } from "react";
+import { useLocation, useNavigate, Link } from "react-router-dom";
+import styled from "styled-components";
+import { COLORS } from "../../constants";
+
+export default function SearchResult() {
+  const location = useLocation();
+
+  const navigate = useNavigate();
+
+  const [search, setSearch] = useState(location.state);
+  const onChangeSearch = (e) => {
+    e.preventDefault();
+    setSearch(e.target.value);
+  };
+
+  const searchDummy = [
+    {
+      id: 1,
+      word: location.state + " 맨션 (Suspects)",
+    },
+    {
+      id: 2,
+      word: location.state + " 사건 사고",
+    },
+    {
+      id: 3,
+      word: location.state + " 블로그",
+    },
+    {
+      id: 4,
+      word: location.state + " 불가사의",
+    },
+    {
+      id: 5,
+      word: location.state + " 캔디",
+    },
+    {
+      id: 6,
+      word: location.state + " 부루마블",
+    },
+    {
+      id: 7,
+      word: location.state + " 산장의 기억",
+    },
+    {
+      id: 8,
+      word: location.state + " 오레오",
+    },
+  ];
+
+  const onSubmit = (e) => {
+    e.preventDefault();
+    navigate(`/search/${search}`, { state: search });
+  };
+
+  return (
+    <>
+      <Form onSubmit={onSubmit}>
+        <Label htmlFor="search">
+          <SearchInp
+            id="search"
+            type="text"
+            placeholder="Search"
+            value={search}
+            onChange={onChangeSearch}
+          />
+          <button type="submit"></button>
+        </Label>
+      </Form>
+      <ul>
+        {searchDummy.map((v) => {
+          return (
+            <SearchList>
+              <Link to={`/detail`}>
+                <span>{v.word}</span>
+              </Link>
+            </SearchList>
+          );
+        })}
+      </ul>
+    </>
+  );
+}
+
+const Form = styled.form`
+  margin: 4.4rem auto 1.2rem;
+  width: calc(100% - 3rem);
+`;
+
+const Label = styled.label`
+  position: relative;
+  &::before {
+    content: "";
+    position: absolute;
+    top: 50%;
+    transform: translate(50%, -50%);
+    width: 1.5rem;
+    height: 1.5rem;
+    background: url("/img/search.svg") no-repeat center;
+  }
+  button {
+    display: none;
+  }
+`;
+
+const SearchInp = styled.input`
+  display: block;
+  padding: 0.4rem 1rem 0.4rem 3rem;
+  width: 100%;
+  height: 3.125rem;
+  border: none;
+  border-radius: 0.5rem;
+  background: ${COLORS.light_white};
+  color: ${COLORS.black};
+  &:focus {
+    outline: none;
+  }
+  &::placeholder {
+    color: ${COLORS.gray};
+  }
+`;
+
+const SearchList = styled.li`
+  margin: 0.7rem auto;
+  width: calc(100% - 3.7rem);
+  font-size: 0.92rem;
+  span {
+    display: block;
+    padding: 1.3rem 0;
+    width: 100%;
+  }
+`;

--- a/FrontEnd/poyo/src/pages/Search.js
+++ b/FrontEnd/poyo/src/pages/Search.js
@@ -1,0 +1,9 @@
+import SearchResult from "../components/search/SearchResult";
+
+export default function Search() {
+  return (
+    <>
+      <SearchResult />
+    </>
+  );
+}

--- a/FrontEnd/poyo/src/pages/Search.js
+++ b/FrontEnd/poyo/src/pages/Search.js
@@ -1,8 +1,10 @@
+import { BackButton } from "../components/BackBtn";
 import SearchResult from "../components/search/SearchResult";
 
 export default function Search() {
   return (
     <>
+      <BackButton />
       <SearchResult />
     </>
   );


### PR DESCRIPTION
## 세부 사항
- 검색 결과 페이지 UI를 설계해 주었습니다.
- 검색어 입력 시, 검색 결과 페이지를 동적 라우팅으로 연결해 주었습니다.
- 뒤로가기 버튼을 컴포넌트화 해주었습니다.
- 홈 화면의 인기 검색어 부분을 랭킹으로 변경하였습니다.

## 스크린샷 (기능 구현 시)
![image](https://user-images.githubusercontent.com/92927950/172652811-cd6a50e0-98b3-4fa3-ae03-c2854100ce7b.png)

## 기타 질문 및 특이 사항
- 더미데이터를 만들었습니다. api 연결 시 삭제하도록 하겠습니다.
- UI 부분에 대해 의견 있으시면 편하게 이야기해주세요!

## 체크 리스트
- [x] 필요한 기능이 제대로 실행되는지 확인 하였습니다.
- [x] 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
